### PR TITLE
Implement Canonical URL

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,8 @@
     {{ end }}
 </title>
 
+<link rel="canonical" href="{{ .Permalink }}" />
+
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}
 


### PR DESCRIPTION
This change adds canonical URL to all pages.

Reference: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method