### PR TITLE
Added a configurable option to open a new tab when clicking on the menu and support for Umami along with relevant configurable options.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,3 +23,7 @@
 {{ if hugo.IsProduction }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
+
+{{ if .Site.Params.umami.enable }}
+  {{ partial "umami.html" . }}
+{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,8 +12,8 @@
         {{ with site.Params.menu }}
         {{ range . }}
         <p class="small {{ if eq .url $currentPage.Path }} bold {{end}}">
-            <a href="{{.url}}">
-                /{{.name }}
+            <a href="{{ .url }}" {{ if and (isset . "newTab") .newTab }}target="_blank" rel="noopener noreferrer"{{ end }}>
+                /{{ .name }}
             </a>
         </p>
         {{ end }}

--- a/layouts/partials/umami.html
+++ b/layouts/partials/umami.html
@@ -1,0 +1,6 @@
+<script
+  async
+  defer
+  data-website-id="{{ .Site.Params.umami.websiteId }}"
+  src="{{ .Site.Params.umami.jsLocation }}"
+></script>


### PR DESCRIPTION
```
[[params.menu]]
name = "posts"
url = "/posts"
newTab = true
```

`newTab = true` is an optional setting and can be omitted.