### PR TITLE
header partial: replace deprecated .Path access with lower .Name

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,7 @@
 
         {{ with site.Params.menu }}
         {{ range . }}
-        <p class="small {{ if eq .url $currentPage.Path }} bold {{end}}">
+        <p class="small {{ if eq .name (lower $currentPage.Name) }} bold {{end}}">
             <a href="{{.url}}">
                 /{{.name }}
             </a>


### PR DESCRIPTION
building the example blog on main gives this warning about the header on build, and the bolding was not working anyway.


```console
WARN  .Path when the page is backed by a file is deprecated. We plan to use Path for a canonical source path and you probably want to check the source is a file. To get the current behaviour, you can use a construct similar to the one below:

  {{ $path := "" }}
  {{ with .File }}
	{{ $path = .Path }}
  {{ else }}
	{{ $path = .Path }}
  {{ end }}
```

This seems to be a decent updated way to accomplish bolding the menu entry for the current page, which I assume was the original intent.
It does not accomplish bolding the section for child pages, as in `/posts` menu section will not be bold when viewing the `posts/hugo-images/` page, but I do not think the original did that either - that would require doing some work on `path.Split`