### PR TITLE
Allow the date/time format on the single template to be overridden

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -22,7 +22,7 @@
     <p class="single-readtime">
       {{ with .Date }}
       {{ $dateMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
-      {{ $dateHuman := . | time.Format ":date_long" }}
+      {{ $dateHuman := . | time.Format (default ":date_long" $.Site.Params.singleDateFormat) }}
       <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
       {{end}}
 


### PR DESCRIPTION
Example:

```toml
[params]
singleDateFormat = '2 January 2006'
```