### PR TITLE
Enable Umami analytics in Production only

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,8 +34,9 @@
 
 {{ if hugo.IsProduction }}
 {{ template "_internal/google_analytics.html" . }}
-{{ end }}
 
 {{ if .Site.Params.umami.enable }}
 {{ partial "umami.html" . }}
 {{ end }}
+{{ end }}
+


### PR DESCRIPTION
This will prevent analytics collection when testing locally.