### PR TITLE
single view: markdownify summary

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,7 +14,7 @@
 
     <h1 class="single-title">{{ .Title }}</h1>
     {{ with .Param "summary" }}
-    <p class="single-summary">{{ . }}</p>
+    <p class="single-summary">{{ . | markdownify }}</p>
     {{ end }}
 
     {{/* Reading Time */}}


### PR DESCRIPTION
Hi,

The summary is not markdownified, and thus we see the md content on the summary. This fixes that

Thanks!