### PR TITLE
Add support for Open Graph tags

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,6 +29,8 @@
 
 <link rel="canonical" href="{{ .Permalink }}"/>
 
+{{ template "_internal/opengraph.html" . }}
+
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}
 


### PR DESCRIPTION
This change will allow us to use the `images` property in frontmatter to display a cover image when sharing links to content in social media.

Open Graph support is provided out of the box with Hugo and is a one-line change. See docs: https://gohugo.io/templates/embedded/#open-graph

Here's an example of an article from my site using this change locally: https://www.opengraph.xyz/url/https%3A%2F%2Fblog.sangeeth.dev%2Fposts%2Fthanos-snap-safari-sequoia%2F