### PR TITLE
Make header title a link to base URL (home page)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -141,6 +141,10 @@ hr {
   margin-top: 0;
 }
 
+.header-title a {
+  text-decoration: none;
+}
+
 /* Footer */
 
 footer {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,9 @@
 
     {{ if or (not (.Param "hideHeader")) .IsHome }}
 
-    <h1 class="header-title">{{ site.Title }}</h1>
+    <h1 class="header-title">
+        <a href="{{ site.BaseURL }}">{{ site.Title }}</a>
+    </h1>
 
     <div class="flex">
         {{ $currentPage := . }}


### PR DESCRIPTION
This is a common pattern found in many sites. I've also added styling to remove the underline.