### PR TITLE
Opengraph tags are not correctly recognized

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,8 @@
 
 {{ $faviconPath := (.Site.Params.faviconPath | default "" | absURL) }}
 
+{{ template "_internal/opengraph.html" . }}
+
 <link rel="icon" type="image/ico" href="{{ $faviconPath }}/favicon.ico">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ $faviconPath }}/favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ $faviconPath }}/favicon-32x32.png">
@@ -28,8 +30,6 @@
 </title>
 
 <link rel="canonical" href="{{ .Permalink }}"/>
-
-{{ template "_internal/opengraph.html" . }}
 
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}


### PR DESCRIPTION
## Description
Moved opengraph template to the top instead of bottom.

I've noticed that doing this change help services (like Telegram, Whatsapp...) in recognizing the OpenGraph tags and correctly preview pages.

Before almost everytime I tried to send a link on Telegram or any other platform, preview wasn't generated.