### PR TITLE
Add article heading anchors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -37,6 +37,19 @@ h6 {
   margin-bottom: var(--hx-margin-bottom);
 }
 
+.heading {
+  a {
+    text-decoration: none;
+    color: var(--content-secondary);
+    visibility: hidden;
+    font-size: 0.95em;
+  }
+
+  &:hover a {
+    visibility: visible;
+  }
+}
+
 p {
   margin-top: var(--p-margin-top);
   margin-bottom: var(--p-margin-bottom);

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,4 @@
+<h{{ .Level }} class="heading" id="{{ .Anchor }}">
+  {{ .Text }}
+  <a href="#{{ .Anchor }}">#</a>
+</h{{ .Level }}>


### PR DESCRIPTION
Adds heading anchors (#) that appear when user hovers over headings in articles. Clicking the anchor will scroll viewport until heading is aligned to top and update the address bar with the hash. This makes it easy to copy URLs that link to a specific heading in the article.

https://github.com/user-attachments/assets/00b4dc26-347f-48db-9253-7e497300eb1f
