### PR TITLE
Adding support for translating dates

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,6 @@
 baseURL = 'https://example.org/'
 languageCode = 'en-us'
+defaultContentLanguage = 'en-us'
 title = 'typo'
 
 [module]

--- a/layouts/partials/post-entry.html
+++ b/layouts/partials/post-entry.html
@@ -5,7 +5,7 @@
     {{ $dateFormat = .}}
     {{ end }}
 
-    <p class="line-date">{{ .Date.Format $dateFormat }} </p>
+    <p class="line-date">{{ .Date | time.Format $dateFormat }} </p>
 
     <div>
         <p class="line-title">


### PR DESCRIPTION
Hugo already provides [date translation](https://gohugo.io/content-management/multilingual/#dates). Actually `single.html` already supported it, now I added it for `post-entry.html`

Perhaps wiki needs to be updated in [Site Config](https://github.com/tomfran/typo/wiki/Setup#21-site-config) to add  `defaultContentLanguage` parameter. Maybe also worth a mention in the [Features](https://github.com/tomfran/typo/wiki/Features)?