### PR TITLE
Fix: overwriting footer.html breaks math

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,7 +27,11 @@
     <footer>
       {{ partial "footer.html" . }}
     </footer>
-    
+
+    {{ if .Param "math" }}
+    {{ partialCached "math.html" . }}
+    {{ end }}
+
   </body>
 
   <script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,3 @@
     <p>{{ . | markdownify }}</p>
     {{ end }}
 {{ end }}
-
-{{ if .Param "math" }}
-{{ partialCached "math.html" . }}
-{{ end }}


### PR DESCRIPTION
Yes, you can customize the footer with param `footerContent` in `config.toml`. But another way of doing it is creating your own `footer.html` like so:
```
my-site/
├── layouts/
|   └── partials/
|   |   └── footer.html  <--
├── themes/
|   └── typo/
```

However if you do that, it breaks math on the site, because the "math block" is inside the theme's `footer.html`.

@tomfran this is just one way I could think of solving the issue, let me know what you think :)

P.s. Thanks for the amazing theme! 