### PR TITLE
Add support for installing theme as Hugo module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/crnh/typo
+module github.com/tomfran/typo
 
 go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/crnh/typo
+
+go 1.20


### PR DESCRIPTION
This PR adds a `go.mod` file to allow installing this theme as a Hugo module using the `hugo mod` subcommand. I prefer to use Hugo modules instead of git submodules wherever possible, as they are more flexible.

This is how to install the theme as a Hugo module (I cannot edit the wiki, but it could be nice to add the installation instructions there as well):

1. `hugo mod init module_name`
2. `hugo mod get github.com/tomfran/typo`
3. Add the following to `hugo.toml`:
    ```toml
    [module]
    [[module.imports]]
    path = "github.com/tomfran/typo"
    ```
4. Remove the `theme = 'typo'` parameter from `hugo.toml`, as this parameter is only intended for themes in the `themes/` directory.

Thanks a lot for this great theme!