### PR TITLE
Adding parameter `disableComment` to disable Giscus comment on specific post.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -65,8 +65,8 @@
 
   <div class="single-content">
     {{ .Content }}
-    {{ if not .Params.disableComment }}
     {{ if .Site.Params.giscus.enable }}
+    {{ if not .Params.disableComment }}
     {{ partial "comments.html" . }}
     {{ end }}
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -65,8 +65,10 @@
 
   <div class="single-content">
     {{ .Content }}
+    {{ if not .Params.disableComment }}
     {{ if .Site.Params.giscus.enable }}
     {{ partial "comments.html" . }}
+    {{ end }}
     {{ end }}
   </div>
 


### PR DESCRIPTION
This basically adds a feature to disable giscus comments on certain posts by adding the `disableComment` parameter to the markdown file. By default, this will be set to `false` even if the user does not add this parameter.

example :
```
---
disableComment: true
---
```

This parameter is actually to fulfill my needs, but if it can help other users, why not :)