### PR TITLE
Fix mermaid diagrams

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,4 +1,4 @@
 <pre class="mermaid">
-  {{- .Inner | safeHTML }}
+  {{- .Inner | htmlEscape | safeHTML }}
 </pre>
 {{ .Page.Store.Set "hasMermaid" true }}

--- a/static/js/copy-code.js
+++ b/static/js/copy-code.js
@@ -2,6 +2,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const codeBlocks = document.querySelectorAll("pre");
 
   codeBlocks.forEach((codeBlock) => {
+    if (codeBlock.className == "mermaid") return;
     const copyButton = document.createElement("button");
     copyButton.className = "copy-code-button";
     copyButton.textContent = "copy";


### PR DESCRIPTION
The "copy code" button breaks the rendering of mermaid diagrams. This PR omits the button on mermaid diagrams to restore displaying the rendered SVG. The "code" from the diagram is not shown to the user, so there is no need for a "copy code" button on those.

A second change (not strictly necessary to fix the original issue) updates the `render-codeblock-mermaid.html` file to also escape HTML code, conforming to the Hugo recommendation listed here: https://gohugo.io/content-management/diagrams/#mermaid-diagrams

Please let me know if you would like to omit the second change and I'll update the PR.

Closes #69 