### PR TITLE
Small wiki fixes

### DIFF
--- a/wiki/features/other-parameters.md
+++ b/wiki/features/other-parameters.md
@@ -69,7 +69,7 @@ jsLocation = "http://example.org/umami.js"
 
 The following favicons are included in the head of the website: 
 - `favicon.ico`
-- `favicon-16xng`
+- `favicon-16x16.png`
 - `favicon-32x32.png`
 - `android-chrome-192x192.png`
 - `apple-touch-icon.png`

--- a/wiki/features/single-page-parameters.md
+++ b/wiki/features/single-page-parameters.md
@@ -79,6 +79,14 @@ You can specify the post meta description as follows:
 description: "Your Description"
 ```
 
+## Fediverse
+
+You can include a [fediverse handle](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) in your posts.
+
+```md
+fediverse: "@username@instance.url"
+```
+
 ## Date Format
 
 You can decide the date format to apply to single posts by setting the following param in the toml file: 
@@ -86,13 +94,4 @@ You can decide the date format to apply to single posts by setting the following
 ```toml
 [params]
 singleDateFormat = '2 January 2006'
-```
-
-## Fediverse
-
-You can include a [fediverse handle](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) in your posts.
-
-```toml
-[params]
-fediverse: "@username@instance.url"
 ```


### PR DESCRIPTION
Fixes for a couple of small mistakes I found in the wiki.

For the fediverse one, the author of the PR #67 meant it to be a param in the `.md` file of each post. However the `[params]` line in the wiki initally confused me and I thought it was meant for the `hugo.toml` file. I removed the `[params]` line and also moved the block one up (to leave Date Format last which is the only one of these that is actually meant for `hugo.toml`).