### PR TITLE
Fix whitespace around #small images

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -457,7 +457,13 @@ figure img {
 }
 
 .img-small img {
-  scale: 80%;
+  max-height: calc(var(--figure-img-max-height) * 0.8);
+}
+
+.img-small div:first-child {
+  height: 80%;
+  width: 80%;
+  margin: auto;
 }
 
 .img-full div {


### PR DESCRIPTION
Tested with square, tall and wide images.

`.img-small div:first-child` selects the image container and omits the caption. It's a bit hacky and it would be cleaner for it to have an actually selectable tag. For now, this works though.

Fixes https://github.com/tomfran/typo/issues/74