### PR TITLE
Fix disappearing header links

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,7 +38,7 @@ h6 {
 }
 
 .heading {
-  a {
+  .anchor {
     text-decoration: none;
     font-weight: normal;
     color: var(--content-secondary);
@@ -47,7 +47,7 @@ h6 {
     font-family: var(--font-mono);
   }
 
-  &:hover a {
+  &:hover .anchor {
     visibility: visible;
   }
 }

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,4 +1,4 @@
 <h{{ .Level }} class="heading" id="{{ .Anchor }}">
   {{ .Text }}
-  <a href="#{{ .Anchor }}">#</a>
+  <a class="anchor" href="#{{ .Anchor }}">#</a>
 </h{{ .Level }}>


### PR DESCRIPTION
This PR gives the anchor hashes their own class `anchor`, which allows the CSS mouse-over behavior to be more targeted. Normal hyperlinks in headers are now visible again.

Fixes https://github.com/tomfran/typo/issues/77