### PR TITLE
Fix the path to the custom css file in the wiki article

### DIFF
--- a/wiki/features/custom-css.md
+++ b/wiki/features/custom-css.md
@@ -11,7 +11,7 @@ showTags: false
 hideBackToTop: true
 ---
 
-The theme supports custom css, you can override anything you want by redefining classes in the `assets/custom.css` file.
+The theme supports custom css, you can override anything you want by redefining classes in the `assets/css/custom.css` file.
 
 For instance, changing the main width can be done as follows: 
 


### PR DESCRIPTION
I noticed an invalid path in the wiki article. Fixed it.