### PR TITLE
List alignment fixes and input dark mode support

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -59,17 +59,29 @@ p {
   line-height: var(--p-line-height);
 }
 
-ul {
-  margin-top: var(--ul-margin-top);
-  margin-bottom: var(--ul-margin-bottom);
-}
-
 li {
   margin-left: var(--li-indent);
+
+  &:has(> input[type="checkbox"]) {
+    list-style-type: none;
+  }
+
+  & > input[type="checkbox"] {
+    width: var(--li-checkbox-size);
+    height: var(--li-checkbox-size);
+    margin: 0 0.2em 0.15em -1.25em;
+    vertical-align: middle;
+  }
 }
 
 a {
   text-decoration: underline;
+}
+
+input {
+  .dark & {
+    color-scheme: dark;
+  }
 }
 
 /* Code blocks */

--- a/assets/css/reset.css
+++ b/assets/css/reset.css
@@ -64,7 +64,7 @@ p {
     margin-bottom: 0;
 }
 
-ul {
+ul, ol {
     padding: 0;
 }
 

--- a/assets/css/vars.css
+++ b/assets/css/vars.css
@@ -33,10 +33,13 @@
     --p-line-height: 1.5em;
     --caption-font-size: .8em;
 
-    /* List indentation */
-    --li-indent: 1.5rem;
+    /* Lists */
+    --li-indent: 2rem;
     --ul-margin-top: 1rem;
     --ul-margin-bottom: 1rem;
+    --li-checkbox-size: 0.8em;
+
+    /* TOC */
 
     --toc-margin-top: 2rem;
     --toc-margin-bottom: 3rem;


### PR DESCRIPTION
Fixes margin and alignment issues in ul, ol and checkbox lists including when they are nested within each other.

input elements in dark mode are forced to be in browser's dark color scheme.

## Screenshots

![CleanShot 2025-03-06 at 10 01 21@2x](https://github.com/user-attachments/assets/5b184cae-f6d4-49eb-8ced-84ae79d57d44)
![CleanShot 2025-03-06 at 10 01 38@2x](https://github.com/user-attachments/assets/f4a7aff7-1084-48ae-afce-22532a5d3626)

Have also tested this against the existing lists on my blog and they look better now.