### PR TITLE
Add breadcrumbs config to hide current page and change home text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+.idea/

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -524,14 +524,12 @@ figcaption {
 /* breadcrumbs */
 
 .breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
   font-size: small;
   margin-bottom: calc(-0.5 * var(--h1-margin-top));
   font-family: var(--font-mono);
-}
-
-.breadcrumbs span {
-  margin-right: -5px;
-  margin-left: -5px;
 }
 
 /* Comments */

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,3 +7,9 @@ title = 'typo'
 [module.hugoVersion]
 extended = false
 min = "0.116.0"
+
+# Default config
+[params.breadcrumbs]
+enabled = true
+showCurrentPage = true
+home = "Home"

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,9 +1,23 @@
-{{ if .Site.Params.breadcrumbs }}
+{{- if .Site.Params.breadcrumbs.enabled -}}
+{{- $breadcrumbs := .Site.Params.breadcrumbs -}}
 <div class="breadcrumbs">
-    {{ range .Ancestors.Reverse }}
-    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-    <span class="breadcrumbs-separator"> / </span>
-    {{ end }}
-    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    {{- range $i, $v := .Ancestors.Reverse -}}
+        <a href="{{ .RelPermalink }}">
+            {{- if (and (eq $i 0) (ne $breadcrumbs.home "")) -}}
+                {{- $breadcrumbs.home -}}
+            {{- else -}}
+                {{- .Title -}}
+            {{- end -}}
+        </a>
+        
+        {{- if (lt $i (sub $.Ancestors.Len 1)) -}}
+            <span class="breadcrumbs-separator">/</span>
+        {{- end -}}
+    {{- end -}}
+
+    {{- if $breadcrumbs.showCurrentPage -}}
+        <span class="breadcrumbs-separator">/</span>
+        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    {{- end -}}
 </div>
-{{ end }}
+{{- end -}}

--- a/wiki/features/other-parameters.md
+++ b/wiki/features/other-parameters.md
@@ -25,10 +25,20 @@ description = "Your description"
 
 Show breadcrumbs on pages.
 
+Example:
+
 ```toml
-[params]
-breadcrumbs = true
+[params.breadcrumbs]
+enabled = true
+showCurrentPage = true
+home = "~"
 ```
+
+Set `enabled` to `false` if you want to hide breadcrumbs. By default, breadcrumbs are shown.
+
+Set `showCurrentPage` to `false` to hide the last crumb, i.e, the current page.
+
+`home` when set with a non-empty string, uses the latter as the first crumb instead of the string "Home".
 
 ## Comments
 

--- a/wiki/setup.md
+++ b/wiki/setup.md
@@ -114,8 +114,9 @@ paginationSize = 100
 listSummaries = true
 listDateFormat = '2 Jan 2006'
 
-# Breadcrumbs
-breadcrumbs = true
+# Breadcrumbs (Uncomment to disable)
+# [params.breadcrumbs]
+# enabled = false
 
 # Social icons
 [[params.social]]


### PR DESCRIPTION
Changes `breadcrumbs` config into an object to add customizations such as hiding current page and changing the text of
the home crumb.

Preserves the existing default of disabling breadcrumbs. If breadcrumbs are enabled, the current default of showing the
current page crumb is also preserved.

BREAKING CHANGE: `breadcrumbs` is now an object so existing `breadcrumbs = true` line in config needs to be changed.
Closes: #93

---

To keep config straightforward, I changed the type but this breaks it for current users and they'll have to change:

```
breadcrumbs = true
```

into

```
[params.breadcrumbs]
enabled = true
```

to get hugo to build again. If that's not a desired effect, could have a `breadcrumbsConfig` key separately. 