### PR TITLE
Improve 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,7 +4,7 @@
 
     <div>
         <h1> typo? </h1>
-        <p> Click <a href="/"> here </a> to return to home </p>
+        <p> Click <a href="/">here</a> to return to home </p>
     </div>
 
 </div>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,7 +4,7 @@
 
     <div>
         <h1> typo? </h1>
-        <p> Click <a href="/">here</a> to return to home </p>
+        <p> Click <a href="/">here</a> to return home </p>
     </div>
 
 </div>


### PR DESCRIPTION
Removes spacing around the "return home" anchor tag (as it leads to underlines being displayed beyond the link itself) in the 404 page:
![Screenshot From 2025-03-14 18-57-35](https://github.com/user-attachments/assets/16385e05-22ea-4098-8b87-624b5dab033d)

Also changes "return to home" wording to "return home" which sounds more natural. 