### PR TITLE
Remove `px` from width/height img attributes in render-image hook

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -47,7 +47,7 @@ and build the img class string as "img-tag1 img-tag2 ..."
 <figure class="{{ $classes }}">
 
     <div>
-        <img loading="lazy" alt="{{ .Text }}" src="{{ $url }}" {{ with $imgResource }}width="{{ .Width }}px" height="{{ .Height }}px"{{ end }}>
+        <img loading="lazy" alt="{{ .Text }}" src="{{ $url }}" {{ with $imgResource }}width="{{ .Width }}" height="{{ .Height }}"{{ end }}>
     </div>
 
     {{ with .Title }}


### PR DESCRIPTION
As per the spec, width/height attrs should be non-negative integers but
currently, they are being rendered with a `px` suffix. This change removes
the suffix which hopefully fixes any outstanding layout shifts.

References:
- https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes

---

Miss from my end and hopefully resolves some of the content shifts mentioned in #81 and #87 though won't bet on that.
