### PR TITLE
Fix layout shifts by preserving aspect-ratio at responsive sizes

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -440,18 +440,19 @@ footer a {
 
 /* images */
 
-figure>div {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}
+figure {
+  .img-container {
+    aspect-ratio: var(--w) / var(--h);
+    max-height: var(--figure-img-max-height);
+    width: auto;
+    margin-inline: auto;
+  }
 
-figure img {
-  max-width: 100%;
-  max-height: var(--figure-img-max-height);
-  width: auto;
-  height: auto;
-  margin-inline: auto;
+  img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
 }
 
 .dark .img-light {

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -46,7 +46,7 @@ and build the img class string as "img-tag1 img-tag2 ..."
 {{/* Use the computed classes on the rendered figure */}}
 <figure class="{{ $classes }}">
 
-    <div>
+    <div class="img-container" {{ with $imgResource }}style="--w: {{ .Width }}; --h: {{ .Height }};"{{ end }}>
         <img loading="lazy" alt="{{ .Text }}" src="{{ $url }}" {{ with $imgResource }}width="{{ .Width }}" height="{{ .Height }}"{{ end }}>
     </div>
 


### PR DESCRIPTION
Uses `aspect-ratio` property to constrain height and width of render image's container to allow responsive resizing
while maintaining the original aspect ratio and avoiding layout shifts.

Previously, even though `width` and `height` attributes were passed to the `img` element, Chrome (and probably others)
weren't reserving space for the image as expected because CSS `width`/`height` were both `auto`. At least one of them
needed to be a fixed value in order to maintain aspect ratio. Even with this change, it doesn't seem possible to
constrain both width and height on the same element at the same time — only one or the other works.

The change introduced makes the `img` element constrain width using `max-width` while the parent element constrain
height using `max-height` and `aspect-ratio`. This way, we can get responsive sizing on both axes while obeying the
constraints.

---

Here's the Chrome DevTools Performance panel results for the local version of my blog before/after this change. Notice the missing CLS in the "after" version. Note that I couldn't easily get a recording run in my normal profile that highlights this issue so the "before" version is taken in "Guest" profile where this issue is more easily visible and present in the trace:

| Before | After |
| --- | --- |
|  ![CleanShot 2025-03-16 at 08 56 13@2x](https://github.com/user-attachments/assets/6016cbed-b930-4555-8927-141484f60c28) | ![CleanShot 2025-03-16 at 08 49 58@2x](https://github.com/user-attachments/assets/4bc4c73b-99e4-4cd8-a2a9-ad45ad37b51c) |