### PR TITLE
Add hooks for easier customization of layouts

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,6 +32,8 @@
   {{ partialCached "math.html" . }}
   {{ end }}
 
+  {{/* Body end hook */}}
+  {{ partial "functions/get_hook.html" (dict "hook" "body_end" "context" .) }}
 </body>
 
 <script src="{{ "js/theme-switch.js" | relURL }}"></script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,6 +24,9 @@
     </main>
   </div>
 
+  {{/* Body end hook */}}
+  {{ partial "functions/get_hook.html" (dict "hook" "body_end" "context" .) }}
+
   <footer>
     {{ partial "footer.html" . }}
   </footer>
@@ -31,9 +34,6 @@
   {{ if .Param "math" }}
   {{ partialCached "math.html" . }}
   {{ end }}
-
-  {{/* Body end hook */}}
-  {{ partial "functions/get_hook.html" (dict "hook" "body_end" "context" .) }}
 </body>
 
 <script src="{{ "js/theme-switch.js" | relURL }}"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,8 @@
 {{ $showFooter := default true .Site.Params.showFooter }}
 {{ if $showFooter }}
+    {{/* Footer start hook */}}
+    {{ partial "functions/get_hook.html" (dict "hook" "footer_start" "context" .) }}
+
     {{ if not .Site.Params.footerContent }}
     <p>Powered by
         <a href="https://gohugo.io/">Hugo</a>

--- a/layouts/partials/functions/get_hook.html
+++ b/layouts/partials/functions/get_hook.html
@@ -9,15 +9,11 @@
 
 {{ $hook := .hook }}
 {{ $context := .context }}
-{{ $hookName := $hook.Name }}
-{{ $hookType := $hook.Type }}
 
 {{ if not (hasSuffix $hook ".html") }}
     {{ $hook = printf "%s.html" $hook }}
 {{ end }}
 
-{{ $hook_path := path.Join "layouts/partials/hooks" $hook }}
-
-{{ if fileExists $hook_path }}
-    {{ partial $hook_path $context }}
+{{ if fileExists (path.Join "layouts/partials/hooks" $hook) }}   
+    {{ partial (path.Join "hooks" $hook) $context }}
 {{ end }}

--- a/layouts/partials/functions/get_hook.html
+++ b/layouts/partials/functions/get_hook.html
@@ -1,0 +1,23 @@
+{{/* 
+    Customize layouts without overwriting files.
+    Hooks should be defined in the layouts/partials/hooks directory.
+    
+    Parameters:
+    - hook: The name of the hook to be used.
+    - context: The context to be passed to the partial.
+*/}}
+
+{{ $hook := .hook }}
+{{ $context := .context }}
+{{ $hookName := $hook.Name }}
+{{ $hookType := $hook.Type }}
+
+{{ if not (hasSuffix $hook ".html") }}
+    {{ $hook = printf "%s.html" $hook }}
+{{ end }}
+
+{{ $hook_path := path.Join "layouts/partials/hooks" $hook }}
+
+{{ if fileExists $hook_path }}
+    {{ partial $hook_path $context }}
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 
+{{/* Head start hook */}}
+{{ partial "functions/get_hook.html" (dict "hook" "head_start" "context" .) }}
+
 {{ $faviconPath := (.Site.Params.faviconPath | default "" | absURL) }}
 
 <link rel="icon" type="image/ico" href="{{ $faviconPath }}/favicon.ico">
@@ -46,3 +49,5 @@
 {{ end }}
 {{ end }}
 
+{{/* Head end hook */}}
+{{ partial "functions/get_hook.html" (dict "hook" "head_end" "context" .) }}

--- a/wiki/features/hooks.md
+++ b/wiki/features/hooks.md
@@ -1,0 +1,29 @@
+---
+title: "Hooks"
+date: "2024-10-6"
+summary: "Layout hooks"
+description: "Layout hooks"
+toc: false
+readTime: false
+autonumber: true
+math: false
+showTags: false
+---
+
+Hooks allow to customize layouts by injecting custom code at specific points in the layout.
+Hooks are defined in the `layouts/partials/hooks` directory.
+The following hooks are currently available:
+
+- `head_start` is inserted at the beginning of the `<head>` tag.
+- `head_end` is inserted at the end of the `<head>` tag.
+- `body_end` is inserted at the end of the `<body>` tag.
+- `footer_start` is inserted at the beginning of the footer.
+
+To create a hook, add a file named `<hook_name>.html` in the `layouts/partials/hooks` directory. The file should contain the code you want to inject at that point in the layout.
+For example, to preload a font, you can create a file named `head_start.html` in the `layouts/partials/hooks` directory with the following content:
+
+```html
+<link rel="preload" href="/fonts/Literata/Literata-Light.woff2" type="font/woff2" as="font" crossorigin>
+```
+
+The full context is passed to the hook, so any variables available in the page context can be used in the hook.


### PR DESCRIPTION
Add the ability to customize layouts without having to overwrite them. Hooks inject custom code in specific layouts, by adding files in `layouts/partials/hooks`. For example, code in `layouts/partials/hooks/head_start.html` will be injected at the start of the `<head>` tag. A partial `functions/get_hook` is used to check if hook files are present and inject them.

 I also added a wiki page. 

Let me know if you prefer a different implementation!