### PR TITLE
Add major version suffix to go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tomfran/typo
+module github.com/tomfran/typo/v2
 
 go 1.20


### PR DESCRIPTION
Apparently Go module paths must have a major version suffix for major versions larger than 1: https://go.dev/ref/mod#module-path.
This suffix is currently missing in `go.mod`, so the module cannot be upgraded to version 2. I added this suffix to the module path.