### PR TITLE
Displaying a list of posts on the homepage from multiple collections.

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -39,8 +39,7 @@
     <h1> {{ . }} </h1>
     {{ end }}
 
-    {{ $pages := where .Site.RegularPages "Section" .Site.Params.homeCollection
-    }}
+    {{ $pages := where .Site.RegularPages "Section" "in" .Site.Params.homeCollection }}
 
     {{ $paginationSize := 1}}
     {{ if (gt .Site.Params.paginationSize 0) }}

--- a/wiki/features/homepage.md
+++ b/wiki/features/homepage.md
@@ -50,7 +50,7 @@ You can decide to include a collection in your homepage:
 ```toml
 [params]
 homeCollectionTitle = 'Posts'
-homeCollection = 'posts'
+homeCollection = ["posts"]
 ```
 
-The above example includes the `/posts` collection. Note that you can omit the title if you prefer.
+The above example includes the `/posts` collection. You can also add other collections to the array. Note that you can omit the title if you prefer.

--- a/wiki/setup.md
+++ b/wiki/setup.md
@@ -107,7 +107,7 @@ I am interested in a range of topics, including algorithms, distributed systems,
 
 # Collection to display on home
 homeCollectionTitle = 'Posts'
-homeCollection = 'posts'
+homeCollection = ["posts"]
 
 # Lists parameters
 paginationSize = 100


### PR DESCRIPTION
Adjusted the parameter for displaying recent posts on the home page. Considering that we can create multiple sections, it makes more sense to use their list.

In this case, we create an array where we specify the list of sections from which we can display our posts.