### PR TITLE
Update css.html to render inline style

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -23,4 +23,4 @@ $combined := $CSS
 | fingerprint
 }}
 
-<link rel="stylesheet" href="{{ $combined.RelPermalink }}" media="all">
+<style>{{ $combined.Content | safeCSS }}</style>


### PR DESCRIPTION
Having inline css has several benefits: preventing external css file being render blocker, helping browser discover webfonts earlier

Since the css is small enough, it should not hinder any loading performance