### PR TITLE
Make opengraph.html a normal partial

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -36,7 +36,7 @@
 
 <link rel="canonical" href="{{ .Permalink }}"/>
 
-{{ template "_internal/opengraph.html" . }}
+{{ template "partials/opengraph.html" . }}
 
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -44,7 +44,7 @@
   {{- range . | first 6 }}
     <meta property="og:image" content="{{ .Permalink }}">
   {{- end }}
-{{- else -}}
+{{- else }}
 
   {{- /*
     Source modified to load `assets/images/og-image.{webp,png,jpg}` files if any of them exists.
@@ -52,11 +52,11 @@
     as using an external service.
   */ -}}
 
-  {{- if (and (or .IsHome .IsPage) (templates.Exists "partials/head/og-image.html")) -}}
-    {{- $ogImage := partial "head/og-image.html" . -}}
-    {{- with $ogImage -}}
+  {{- if (and (or .IsHome .IsPage) (templates.Exists "partials/head/og-image.html")) }}
+    {{- $ogImage := partial "head/og-image.html" . }}
+    {{- with $ogImage }}
       <meta property="og:image" content="{{ . }}">
-    {{- end -}}
+    {{- end }}
   {{- end }}
   
 {{- end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -52,8 +52,8 @@
     as using an external service.
   */ -}}
 
-  {{- if (and (or .IsHome .IsPage) (templates.Exists "partials/head/og-image.html")) }}
-    {{- $ogImage := partial "head/og-image.html" . }}
+  {{- if templates.Exists "partials/head/og-image.html" }}
+    {{- $ogImage := partial "head/og-image.html" . | strings.TrimSpace }}
     {{- with $ogImage }}
       <meta property="og:image" content="{{ . }}">
     {{- end }}


### PR DESCRIPTION
Moves `opengraph.html` under `layout/partials` and updates `head.html`
to include from the updated path. This change is needed to make things
work with Hugo >=v0.144.0 as they moved templates like
`opengraph.html` from `_internals` breaking existing usage. The doc also recommends doing this: https://gohugo.io/templates/embedded/#open-graph

This change shouldn't affect existing users of Typo unless they override
`head.html`.

Additional changes:

- Include partial in all pages, not sure why I limited it to just home/page types earlier
- the `{{-` and `-}}` changes makes it easier to read the rendered source, no behavioral change.
