### PR TITLE
fixes #129 double slash for favicons 

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,11 +6,11 @@
 
 {{ $faviconPath := (.Site.Params.faviconPath | default "" | absURL) }}
 
-<link rel="icon" type="image/ico" href="{{ $faviconPath }}/favicon.ico">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ $faviconPath }}/favicon-16x16.png">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ $faviconPath }}/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="192x192" href="{{ $faviconPath }}/android-chrome-192x192.png">
-<link rel="apple-touch-icon" sizes="180x180" href="{{ $faviconPath }}/apple-touch-icon.png">
+<link rel="icon" type="image/ico" href="{{ path.Join $faviconPath "favicon.ico" }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ path.Join $faviconPath "favicon-16x16.png" }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ path.Join $faviconPath "favicon-32x32.png" }}">
+<link rel="icon" type="image/png" sizes="192x192" href="{{ path.Join $faviconPath "android-chrome-192x192.png" }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ path.Join $faviconPath "apple-touch-icon.png" }}">
 
 {{ with .OutputFormats.Get "rss" -}}
 {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}


### PR DESCRIPTION
fixes #129
Using path.Join to properly join paths to avoid double slash
Works well with custom faviconPath