### PR TITLE
Move primary content inside an <article> tag

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,70 +7,69 @@
 {{ end }}
 
 <div {{ if .Param "autonumber" }} class="autonumber" {{ end }}>
+  <article>
+    <header class="single-intro-container">
+        {{- /* Title and Summary */}}
+        
+        <h1 class="single-title">{{ .Title }}</h1>
+        {{- with .Param "summary" }}
+        <p class="single-summary">{{ . | markdownify }}</p>
+        {{- end }}
+    
+        {{- /* Reading Time */}}
+    
+        <p class="single-readtime">
+        {{- with .Date }}
+          {{- $dateMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
+          {{- $dateHuman := . | time.Format (default ":date_long" $.Site.Params.singleDateFormat) }}
+          <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+        {{- end }}
+    
+        {{- if .Param "readTime" }}
+          &nbsp; · &nbsp;
+          {{- .ReadingTime }} min read
+        {{- end }}
+        </p>
+    </header>
+    
+    {{- if .Param "showTags" }}
+      {{- $taxonomy := "tags" }}
+      {{- with .Param $taxonomy }}    
+        <div class="single-tags">
+            {{- range $index, $tag := . }}
+            {{- with $.Site.GetPage (printf "/%s/%s" $taxonomy $tag) -}}
+                <span>
+                  <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
+                </span>
+            {{- end }}
+            {{- end }}
+        </div>
+      {{- end }}
+    {{- end }}
+    
+    {{- /* Table of Contents */}}
+    
+    {{- if .Param "toc" }}
+      <aside class="toc">
+        <p><strong>Table of contents</strong></p>
+        {{ .TableOfContents }}
+      </aside>
+    {{- end }}
+    
+    {{- /* Page content */}}
+    
+    <div class="single-content">
+      {{ .Content }}
+    </div>
+  </article>
+  
+  {{- /* Comments */}}
 
-  <div class="single-intro-container">
-
-    {{/* Title and Summary */}}
-
-    <h1 class="single-title">{{ .Title }}</h1>
-    {{ with .Param "summary" }}
-    <p class="single-summary">{{ . | markdownify }}</p>
-    {{ end }}
-
-    {{/* Reading Time */}}
-
-    <p class="single-readtime">
-      {{ with .Date }}
-      {{ $dateMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
-      {{ $dateHuman := . | time.Format (default ":date_long" $.Site.Params.singleDateFormat) }}
-      <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
-      {{end}}
-
-      {{ if .Param "readTime" }}
-      &nbsp; · &nbsp;
-      {{ .ReadingTime }} min read
-      {{end }}
-    </p>
-
-  </div>
-
-  {{ if .Param "showTags" }}
-
-  {{ $taxonomy := "tags" }}
-  {{ with .Param $taxonomy }}
-
-  <div class="single-tags">
-    {{ range $index, $tag := . }}
-    {{ with $.Site.GetPage (printf "/%s/%s" $taxonomy $tag) -}}
-    <span>
-      <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
-    </span>
-    {{ end }}
-    {{ end }}
-  </div>
-
-  {{ end }}
-  {{ end }}
-
-  {{/* Table of Content */}}
-
-  {{ if .Param "toc" }}
-  <aside class="toc">
-    <p><strong>Table of contents</strong></p>
-    {{ .TableOfContents }}
-  </aside>
-  {{ end }}
-
-  {{/* Page content */}}
-
-  <div class="single-content">
-    {{ .Content }}
-    {{ if .Site.Params.giscus.enable }}
-    {{ if not .Params.disableComment }}
-    {{ partial "comments.html" . }}
-    {{ end }}
-    {{ end }}
-  </div>
+  {{- if and .Site.Params.giscus.enable (not .Params.disableComment) }}
+    <div class="single-comments">
+      {{ partial "comments.html" . }}
+    </div>
+  {{- end }}
 
   {{ if .Store.Get "hasMermaid" }}
   {{ $mermaidDarkTheme := default "dark" (or .Params.mermaidDarkTheme .Site.Params.mermaidDarkTheme) }}


### PR DESCRIPTION
Main article will now belong in an \<article> tag and the title/header info will be inside a \<header> tag within the \<article>. Shouldn't introduce any style/functional changes besides improve the semantics.

Comments section is moved outside the \<article> as it doesn't directly relate to the article's contents.

Other changes:

- Used `{{-` to remove some of the whitespace while keeping source HTML structure looking correct

---

I made these changes locally to see if it influenced Safari's Reader Mode but it seems like it's purely LLM driven at the moment, nothing to do with the semantic structure. Still, thought to raise the PR since it's a minor improvement regardless.