### PR TITLE
Fix faviconPath problem

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,11 +6,11 @@
 
 {{ $faviconPath := (.Site.Params.faviconPath | default "" | absURL) }}
 
-<link rel="icon" type="image/ico" href="{{ path.Join $faviconPath "favicon.ico" }}">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ path.Join $faviconPath "favicon-16x16.png" }}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ path.Join $faviconPath "favicon-32x32.png" }}">
-<link rel="icon" type="image/png" sizes="192x192" href="{{ path.Join $faviconPath "android-chrome-192x192.png" }}">
-<link rel="apple-touch-icon" sizes="180x180" href="{{ path.Join $faviconPath "apple-touch-icon.png" }}">
+<link rel="icon" type="image/ico" href="{{ printf `%v%v` $faviconPath  "/favicon.ico" }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ printf `%v%v` $faviconPath "/favicon-16x16.png" }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ printf `%v%v` $faviconPath "/favicon-32x32.png" }}">
+<link rel="icon" type="image/png" sizes="192x192" href="{{ printf `%v%v` $faviconPath "/android-chrome-192x192.png" }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ printf `%v%v` $faviconPath "/apple-touch-icon.png" }}">
 
 {{ with .OutputFormats.Get "rss" -}}
 {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}


### PR DESCRIPTION
## Problem 
![image](https://github.com/user-attachments/assets/b2bc3b5d-b084-4eb1-b0ce-6e51071d4da2)
The favicon path is mistakenly converted to 'http:/https:/tomfran.github.io/typo-wiki/favicon.ico'. According to [Hugo Docs](https://gohugo.io/functions/path/join/),  the behavior of `path.Join` is similar to Join in Golang. So we can also verified this problem in golang as follows.
![image](https://github.com/user-attachments/assets/da75440d-6198-4781-80eb-a2addb80ddc9)

So it is inappropriate to use path.Join in this scenario.

## Solution 

Path is appended directly separated by ‘/’ without causing compatibility issue.
* If faviconPath is not defined, the concatenated path would be like 'http://localhost:1313//favicon.ico', it would be OK.
* If `faviconPath=https://tomfran.github.io` like typo-wiki, the concatenated path would be 'https:/tomfran.github.io/typo-wiki/favicon.ico', it would be OK . 
*  If `faviconPath=https://tomfran.github.io/` , the concatenated path would be 'https:/tomfran.github.io/typo-wiki//favicon.ico', it would be OK too. 

The solution might not be perfect, but it fixs the bug with minimum effort and without sacrificing the compatibility.

Thanks! 
Best wishes.
