### PR TITLE
fix: fix svg render, ignore width/height for now

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -46,9 +46,18 @@ and build the img class string as "img-tag1 img-tag2 ..."
 {{/* Use the computed classes on the rendered figure */}}
 <figure class="{{ $classes }}">
 
-    <div class="img-container" {{ with $imgResource }}style="--w: {{ .Width }}; --h: {{ .Height }};"{{ end }}>
-        <img loading="lazy" alt="{{ .Text }}" src="{{ $url }}" {{ with $imgResource }}width="{{ .Width }}" height="{{ .Height }}"{{ end }}>
-    </div>
+    {{ $text := .Text }}
+    {{ with $imgResource }}
+      {{ if eq $imgResource.MediaType.SubType "svg" }}
+        <div class="img-container">
+            <img loading="lazy" alt="{{ $text }}" src="{{ $url }}">
+        </div>
+      {{ else }}
+        <div class="img-container" style="--w: {{ .Width }}; --h: {{ .Height }};">
+            <img loading="lazy" alt="{{ $text }}" src="{{ $url }}" width="{{ .Width }}" height="{{ .Height }}">
+        </div>
+      {{ end }}
+    {{ end }}
 
     {{ with .Title }}
     <div class="caption-container">


### PR DESCRIPTION
Hi, @tomfran . Thank you for providing the excellent theme. 🥰

This PR fix the image rendering for svg image reousces.

This PR does not address the adjustment of the svg image’s width and height, but as a hotfix, it allows the svg to render correctly without causing an error.

Before #79 and #81 are fixed, I recommend to apply the hotfix to avoid necessary svg usage. 🙏