### PR TITLE
fix code block background

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -112,7 +112,7 @@ pre {
   border-radius: var(--code-border-radius);
   margin-top: var(--code-margin-top);
   margin-bottom: var(--code-margin-bottom);
-  background-color: var(--code-background) !important;
+  background-color: var(--code-background);
   overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;


### PR DESCRIPTION
Related to #164 

Removes `!important` rule from value. This way the code block background is not overwritten. 