### PR TITLE
fix: update og:image handling in opengraph.html for safe image rendering

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -53,9 +53,12 @@
   */ -}}
 
   {{- if templates.Exists "partials/head/og-image.html" }}
-    {{- $ogImage := partial "head/og-image.html" . | strings.TrimSpace }}
+    {{- $ogImage := partial "head/og-image.html" . }}
     {{- with $ogImage }}
-      <meta property="og:image" content="{{ . }}">
+      {{- $ogImageStr := printf "%s" . }}
+      {{- with $ogImageStr }}
+        <meta property="og:image" content="{{ . }}">
+      {{- end }}
     {{- end }}
   {{- end }}
   


### PR DESCRIPTION
Fix for this error I encountered setting up a new blog with this theme:

```
error calling partial: execute of template failed: template: partials/opengraph.html:56:53: executing "partials/opengraph.html" at <strings>: can't evaluate field TrimSpace in type interface {}
```

Steps to reproduce:
1. Create a new hugo blog
2. Setup `typo` theme as detailed [here](https://tomfran.github.io/typo-wiki/setup/)