### PR TITLE
Bump major version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tomfran/typo/v2
+module github.com/tomfran/typo/v3
 
 go 1.20


### PR DESCRIPTION
To install typo v3 as a Go module, the major version in the module name must be bumped.