### PR TITLE
Header accessibility and configuration improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tomfran/typo/v2
+module github.com/tomfran/typo/v3
 
 go 1.20

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,10 +14,11 @@
         {{ with site.Params.menu }}
         {{ range . }}
 
-        <p
-            class="small {{ if eq (lower .name) (lower $currentPage.LinkTitle) }} bold {{end}}">
-            <a href="{{ .url }}" {{ if and (isset . "newTab") .newTab
-                }}target="_blank" rel="noopener noreferrer" {{ end }}>
+        {{ $isCurrentPage := eq (lower .name) (lower $currentPage.LinkTitle) }}
+
+        <p class="small {{ if $isCurrentPage }} bold {{end}}">
+            <a href="{{ .url }}" {{ if and (isset . "newTab" ) .newTab }}target="_blank" rel="noopener noreferrer" {{
+                end }} {{ if $isCurrentPage }}aria-current="page"{{ end }}>
                 /{{.name }}
             </a>
         </p>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,14 +8,14 @@
         <a href="{{ site.BaseURL }}">{{ site.Title }}</a>
     </h1>
 
-    <div class="header-menu">
+    <nav class="header-menu">
         {{ $currentPage := . }}
 
         {{ with site.Params.menu }}
         {{ range . }}
 
         <p
-            class="small {{ if eq .name (lower $currentPage.Name) }} bold {{end}}">
+            class="small {{ if eq (lower .name) (lower $currentPage.LinkTitle) }} bold {{end}}">
             <a href="{{ .url }}" {{ if and (isset . "newTab") .newTab
                 }}target="_blank" rel="noopener noreferrer" {{ end }}>
                 /{{.name }}
@@ -23,7 +23,7 @@
         </p>
         {{ end }}
         {{ end }}
-    </div>
+    </nav>
 
     {{ end }}
 


### PR DESCRIPTION
Accessibility:

- Use a `nav` element instead of a `div`
- Add `aria-current="page"` attribute to the element of the current page

Configuration:

- Compare item name with the `.LinkTitle` attribute instead of `.Name`. This allows to have a different title in the menu / URL than shown on the page. For example, I have a contact page which I want to show as '/contact' in the navigation and the URL, but the page's header shows 'Contact me!'. With this change, the navigation item will still be bold if you are on the contact page.
  - `.LinkTitle` defaults to `.Title` if not set. I tested if `.Name` is equal to `.Title`, and this appeared to be the case (`.Name` is also unset if the title is not set). I also couldn't find anything about the `.Name` method in the Hugo documentation.
- The menu item's name is now also lowercased for comparison, so current page detection will also work for pages with an uppercase title.