### PR TITLE
fix: render external images and SVGs correctly

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -47,16 +47,14 @@ and build the img class string as "img-tag1 img-tag2 ..."
 <figure class="{{ $classes }}">
 
     {{ $text := .Text }}
-    {{ with $imgResource }}
-      {{ if eq $imgResource.MediaType.SubType "svg" }}
-        <div class="img-container">
-            <img loading="lazy" alt="{{ $text }}" src="{{ $url }}">
-        </div>
-      {{ else }}
-        <div class="img-container" style="--w: {{ .Width }}; --h: {{ .Height }};">
-            <img loading="lazy" alt="{{ $text }}" src="{{ $url }}" width="{{ .Width }}" height="{{ .Height }}">
-        </div>
-      {{ end }}
+    {{ if and $imgResource (ne $imgResource.MediaType.SubType "svg") }}
+      <div class="img-container" style="--w: {{ $imgResource.Width }}; --h: {{ $imgResource.Height }};">
+        <img loading="lazy" alt="{{ $text }}" src="{{ $url }}" width="{{ $imgResource.Width }}" height="{{ $imgResource.Height }}">
+      </div>
+    {{ else }}
+      <div class="img-container">
+        <img loading="lazy" alt="{{ $text }}" src="{{ $url }}">
+      </div>
     {{ end }}
 
     {{ with .Title }}
@@ -65,3 +63,4 @@ and build the img class string as "img-tag1 img-tag2 ..."
     </div>
     {{ end }}
 </figure>
+


### PR DESCRIPTION
The issue is in themes/typo/layouts/_default/_markup/render-image.html. The original code only renders the <img> tag if a local resource ($imgResource) is found. External images (which don't have a matching local resource) cause $imgResource to be nil, resulting in the image tag being skipped entirely, even though the <figure> and caption are rendered.

I have modified the template to add a fallback that renders the <img> tag using the original URL when no local resource is found.