### PR TITLE
Use integrity on combined stylesheet

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -23,4 +23,4 @@ $combined := $CSS
 | fingerprint
 }}
 
-<link rel="stylesheet" href="{{ $combined.RelPermalink }}" media="all">
+<link rel="stylesheet" href="{{ $combined.RelPermalink }}" integrity="{{ $combined.Data.Integrity }}" media="all">


### PR DESCRIPTION
The combined stylesheet logic in the "head" partial pipes the combined CSS resource through `fingerprint`, but doesn't actually use the `integrity` attribute on the `<link rel="stylesheet">`. This PR adds that. (By default, `fingerprint` uses SHA-256.)

For comparison, the JavaScript file gets a fingerprint: https://github.com/tomfran/typo/blob/main/layouts/partials/head/js.html#L4

**Example before/after:**
```diff
-<link rel="stylesheet" href="/assets/combined.min.250f6f39f6b03639f082d271f32e1a4b73188f6df4446bf2261557673368e503.css" media="all">
+<link rel="stylesheet" href="/assets/combined.min.250f6f39f6b03639f082d271f32e1a4b73188f6df4446bf2261557673368e503.css" integrity="sha256-JQ9vOfawNjnwgtJx8y4aS3MYj230RGvyJhVXZzNo5QM=" media="all">
```