### PR TITLE
Change paragraph to div for summary

### DIFF
--- a/layouts/partials/post-entry.html
+++ b/layouts/partials/post-entry.html
@@ -14,7 +14,7 @@
         </p>
 
         {{ if .Site.Params.listSummaries }}
-        <p class="line-summary"> {{ .Summary }} </p>
+        <div class="line-summary"> {{ .Summary }} </div>
         {{ end }}
     </div>
 </div>


### PR DESCRIPTION
Hugo's automatic and manual summaries (see https://gohugo.io/content-management/summaries/#manual-summary) are wrapped in a paragraph. Nested paragraphs are invalid, so when the browser renders the summary, it will be placed _after_ the `.line-summary` paragraph, causing the summary to be styled as normal text. Using a `div` for the summary results in correct styling of these summaries, while keeping the styling for summaries specified in the frontmatter intact.