### PR TITLE
fix: update deprecated Hugo language fields

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,12 +1,12 @@
 baseURL = 'https://example.org/'
-languageCode = 'en-us'
+locale = 'en-us'
 defaultContentLanguage = 'en-us'
 title = 'typo'
 
 [module]
 [module.hugoVersion]
 extended = false
-min = "0.116.0"
+min = "0.158.0"
 
 # Default config
 [params.breadcrumbs]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}"
-  dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<html lang="{{ or site.Language.Locale site.Language.Lang }}"
+  dir="{{ or site.Language.Direction `ltr` }}">
 
 <head>
   {{ partial "head.html" . }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -17,7 +17,7 @@
   <meta property="og:description" content="{{ trim . "\n\r\t " }}">
 {{- end }}
 
-{{- with or .Params.locale site.Language.LanguageCode }}
+{{- with or .Params.locale site.Language.Locale }}
   <meta property="og:locale" content="{{ replace . `-` `_` }}">
 {{- end }}
 

--- a/wiki/setup.md
+++ b/wiki/setup.md
@@ -78,7 +78,7 @@ Here is a sample `hugo.toml` config to get started with the theme.
 
 ```toml
 baseURL = 'https://example.org/'
-languageCode = 'en-us'
+locale = 'en-us'
 title = 'My website'
 theme = 'typo'
 


### PR DESCRIPTION
## Summary

- Replace deprecated Hugo language fields with `locale`, `.Language.Locale`, and `.Language.Direction`.
- Update the sample config to match the new key.

## Compatibility

This raises the declared minimum Hugo version from `0.116.0` to `0.158.0`. Hugo currently warns on the old fields, and a future release may remove them.

## Test

- `hugo v0.163.3 --gc --minify --panicOnWarning --baseURL "http://example.com/"`
- `make format-check`
